### PR TITLE
Fix Elementalist link to not require access request

### DIFF
--- a/_posts/2018-01-17-the-elementalist.md
+++ b/_posts/2018-01-17-the-elementalist.md
@@ -1,6 +1,6 @@
 ---
 layout: entry
-link: https://drive.google.com/file/d/0B791qvx7Zs_UVFhCOWdvcVluSFk/edit
+link: https://drive.google.com/file/d/0B791qvx7Zs_UVFhCOWdvcVluSFk/view?usp=sharing&resourcekey=0-x3DZyy_C_zSsXGF6pEZ4yA
 author: Chris Wilson
 source: reddit
 source-url: https://www.reddit.com/r/DungeonWorld/comments/21y068/the_elementalist_an_airbenderstyle_playbook/?st=jchwy7eo&sh=f42a0906


### PR DESCRIPTION
Updating the link for my Elementalist playbook to not require access requests or even a Google login.